### PR TITLE
fix the failing proxied GET requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ app
       // Make the request to the designated service
       const response = await fetch(url, {
         method: clone.method,
-        body: JSON.stringify(await clone.json()),
+        body: clone.body ? JSON.stringify(await clone.json()) : null,
         headers: headers,
       });
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,3 +6,10 @@ export function getMockOpenAI() {
 
   return fetchMock.get("http://api.openai.com");
 }
+
+export function getMockShodan() {
+  const fetchMock = getMiniflareFetchMock();
+  fetchMock.disableNetConnect();
+
+  return fetchMock.get("http://api.shodan.io");
+}


### PR DESCRIPTION
Proxied GET requests were failing due to serialisation of request body which is not required in case of GET requests.