### PR TITLE
add cf-bundle-version field

### DIFF
--- a/migrations/0002_add_bundle_version.sql
+++ b/migrations/0002_add_bundle_version.sql
@@ -1,0 +1,3 @@
+-- Migration number: 0002 	 2024-01-03T01:58:44.126Z
+
+ALTER TABLE requests ADD COLUMN bundle_version TEXT;

--- a/migrations/0002_add_cf_bundle_version.sql
+++ b/migrations/0002_add_cf_bundle_version.sql
@@ -1,3 +1,0 @@
--- Migration number: 0002 	 2024-01-03T01:58:44.126Z
-
-ALTER TABLE requests ADD COLUMN cf_bundle_version TEXT;

--- a/migrations/0002_add_cf_bundle_version.sql
+++ b/migrations/0002_add_cf_bundle_version.sql
@@ -1,0 +1,3 @@
+-- Migration number: 0002 	 2024-01-03T01:58:44.126Z
+
+ALTER TABLE requests ADD COLUMN cf_bundle_version TEXT;

--- a/src/d1/index.ts
+++ b/src/d1/index.ts
@@ -13,6 +13,7 @@ class D1 {
     const xServiceName = this.context.req.raw.headers.get("x-gateway-service-name");
     const xIdentifierForVendor = this.context.req.raw.headers.get("x-gateway-identifier-for-vendor");
     const xBundleIdentifier = this.context.req.raw.headers.get("x-gateway-bundle-identifier");
+    const xBundleVersion = this.context.req.raw.headers.get("x-gateway-bundle-version");
     const url = this.context.req.raw.url;
     const headers = new HeaderUtils(this.context.req.raw.headers).removeSensitiveHeaders().toJsonString();
     const response = this.context.res.clone();
@@ -29,9 +30,10 @@ class D1 {
                               url,
                               headers,
                               status_code,
-                              error
+                              error,
+                              cf_bundle_version
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
     `,
     )
       .bind(
@@ -46,6 +48,7 @@ class D1 {
         headers,
         response.status,
         response.ok ? null : await response.text(),
+        xBundleVersion,
       )
       .run();
   }

--- a/src/d1/index.ts
+++ b/src/d1/index.ts
@@ -31,7 +31,7 @@ class D1 {
                               headers,
                               status_code,
                               error,
-                              cf_bundle_version
+                              bundle_version
         )
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
     `,

--- a/src/d1/models.ts
+++ b/src/d1/models.ts
@@ -12,4 +12,5 @@ export interface RequestModel {
   headers: string;
   status_code: number;
   error: string;
+  cf_bundle_version: string;
 }

--- a/src/d1/models.ts
+++ b/src/d1/models.ts
@@ -12,5 +12,5 @@ export interface RequestModel {
   headers: string;
   status_code: number;
   error: string;
-  cf_bundle_version: string;
+  bundle_version: string;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -204,7 +204,7 @@ describe("Test if the request is proxied to the designated service", () => {
 
     expect(request.identifier_for_vendor).toBe("aaa-bbb-ccc");
     expect(request.status_code).toBe(200);
-    expect(request.cf_bundle_version).toBe("1.0.0");
+    expect(request.bundle_version).toBe("1.0.0");
   });
 
   it("should throw and error if the API key is not found in header and is not set in env.", async () => {
@@ -366,7 +366,7 @@ describe("Test if the request is proxied to the designated service", () => {
 
     expect(request.identifier_for_vendor).toBe("ccc-bbb-aaa");
     expect(request.status_code).toBe(200);
-    expect(request.cf_bundle_version).toBe("2.0.0");
+    expect(request.bundle_version).toBe("2.0.0");
   });
 
   it("should have all the successful request logged in the database", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -177,6 +177,7 @@ describe("Test if the request is proxied to the designated service", () => {
           "x-gateway-service-auth-key": "Authorization",
           "content-type": "application/json",
           "x-gateway-identifier-for-vendor": "aaa-bbb-ccc",
+          "x-gateway-bundle-version": "1.0.0",
         },
         body: JSON.stringify({
           model: "gpt-3.5-turbo",
@@ -203,6 +204,7 @@ describe("Test if the request is proxied to the designated service", () => {
 
     expect(request.identifier_for_vendor).toBe("aaa-bbb-ccc");
     expect(request.status_code).toBe(200);
+    expect(request.cf_bundle_version).toBe("1.0.0");
   });
 
   it("should throw and error if the API key is not found in header and is not set in env.", async () => {
@@ -342,6 +344,7 @@ describe("Test if the request is proxied to the designated service", () => {
           "x-gateway-service-auth-key": "key",
           "content-type": "application/json",
           "x-gateway-identifier-for-vendor": "ccc-bbb-aaa",
+          "x-gateway-bundle-version": "2.0.0",
         },
       },
       BINDINGS,
@@ -363,6 +366,7 @@ describe("Test if the request is proxied to the designated service", () => {
 
     expect(request.identifier_for_vendor).toBe("ccc-bbb-aaa");
     expect(request.status_code).toBe(200);
+    expect(request.cf_bundle_version).toBe("2.0.0");
   });
 
   it("should have all the successful request logged in the database", async () => {


### PR DESCRIPTION
Add `cf-bundle-version` field and use `x-gateway-bundle-version` header to store it for analytics params.