### PR TITLE
feat: add cron to delete data older than X days

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ The following is also recorded:
 
 ## Data Retention
 
-All metadata is kept for a period of 90 days. Beyond this timeframe, the metadata undergoes permanent deletion with **no backup procedures in place.**
+All metadata is kept for a configured amount of period. Beyond this timeframe, the metadata undergoes permanent deletion with **no backup procedures in place.**
 
-To achieve this, a cron job executes every 7 days, targeting metadata older than 90 days for deletion. The configuration for this cron job is stored in the [`wrangler.toml`](./wrangler.toml) file, specifically under the `triggers` section.
+To achieve this, a cron job executes every Sunday 12:00 AM(configurable), targeting metadata older than configured period for deletion. The configuration for this cron job is stored in the [`wrangler.toml`](./wrangler.toml) file, specifically under the `triggers` section.
 
 The cron job is designed to respect the `DELETE_OLD_DATA_BEFORE` environment variable. If this variable is not set, the cron job will intentionally **generate an SQL error**, preventing the deletion of any data.
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,31 @@ All headers are recorded as a JSON blob. Known sensitive headers are stripped fr
 | [`cf-connecting-ip`](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip) | The client IP address connecting to Cloudflare to the origin web server. |
 | [`cf-ipcountry`](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-ipcountry) | The two-character country code of the originating visitor’s country. |
 | `x-gateway-service-id` | The requested service's identifier. |
-| `x-gateway-service-name` | The requested service's human readable name. | 
+| `x-gateway-service-name` | The requested service's human readable name. |
 | `x-gateway-identifier-for-vendor` | An alphanumeric string that uniquely identifies a device to the connecting application’s vendor. |
 | `x-gateway-bundle-identifier` | The connecting application's bundle identifier. |
 | `x-gateway-bundle-version` | The connecting applications version number. |
 
 The following is also recorded:
 * Full URL of the request
-* Responses status code 
+* Responses status code
 * Any server specific errors
+
+## Data Retention
+
+All metadata is kept for a period of 90 days. Beyond this timeframe, the metadata undergoes permanent deletion with **no backup procedures in place.**
+
+To achieve this, a cron job executes every 7 days, targeting metadata older than 90 days for deletion. The configuration for this cron job is stored in the [`wrangler.toml`](./wrangler.toml) file, specifically under the `triggers` section.
+
+The cron job is designed to respect the `DELETE_OLD_DATA_BEFORE` environment variable. If this variable is not set, the cron job will intentionally **generate an SQL error**, preventing the deletion of any data.
+
+#### DELETE_OLD_DATA_BEFORE variable Format
+
+```
+[sign] quantity unit
+```
+
+- `sign`: Optional. Use `+` for addition and `-` for subtraction.
+- `quantity`: Numeric value.
+- `unit`: Time unit (`year(s)`, `month(s)`, `day(s)`, `hour(s)`, `minute(s)`, `second(s)`).
+

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
+    "dev:scheduled": "wrangler dev --test-scheduled",
     "start": "wrangler dev",
     "lint": "eslint --ext .js,.ts,.tsx ./src --fix",
     "test": "jest"

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,1 +1,6 @@
-export type Bindings = { [key: string]: string | null | undefined } & { DB: D1Database };
+export type Bindings = {
+  [key: string]: string | null | undefined
+} & {
+  DB: D1Database,
+  DELETE_OLD_DATA_BEFORE: string
+};

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -3,4 +3,5 @@ export type Bindings = {
 } & {
   DB: D1Database,
   DELETE_OLD_DATA_BEFORE: string
+  DELETE_OLD_DATA_CRON: string
 };

--- a/src/crons/cron.ts
+++ b/src/crons/cron.ts
@@ -4,7 +4,7 @@ import delete_old_data_cron from "./delete_old_data_cron";
 
 async function cron(event: ScheduledEvent, env: Bindings, context: ExecutionContext) {
   switch (event.cron) {
-    case "0 0 */7 * *":
+    case env.DELETE_OLD_DATA_CRON:
       await delete_old_data_cron(env);
       break;
     default:

--- a/src/crons/cron.ts
+++ b/src/crons/cron.ts
@@ -1,0 +1,16 @@
+import { Bindings } from "../bindings";
+import { ExecutionContext } from "hono/dist/types/context";
+import delete_old_data_cron from "./delete_old_data_cron";
+
+async function cron(event: ScheduledEvent, env: Bindings, context: ExecutionContext) {
+  switch (event.cron) {
+    case "0 0 */7 * *":
+      await delete_old_data_cron(env);
+      break;
+    default:
+      context.passThroughOnException();
+      console.warn(`Unknown cron job: ${event.cron}`);
+  }
+}
+
+export default cron;

--- a/src/crons/delete_old_data_cron.ts
+++ b/src/crons/delete_old_data_cron.ts
@@ -14,7 +14,7 @@ async function delete_old_data_cron(env: Bindings) {
     throw `Delete old data cron failed: ${response.error}`;
   }
 
-  console.info(`Delete old data cron completed successfully.\nMetadata: ${response.meta}`);
+  console.info(`Delete old data cron completed successfully.\nMetadata: ${JSON.stringify(response.meta)}`);
   return response.meta;
 }
 

--- a/src/crons/delete_old_data_cron.ts
+++ b/src/crons/delete_old_data_cron.ts
@@ -1,0 +1,21 @@
+import { Bindings } from "../bindings";
+
+
+async function delete_old_data_cron(env: Bindings) {
+  const response = await env.DB.prepare(`
+      DELETE
+      FROM requests
+      WHERE created_at < datetime('now', ?1)
+  `)
+    .bind(env.DELETE_OLD_DATA_BEFORE)
+    .run();
+
+  if (response.error) {
+    throw `Delete old data cron failed: ${response.error}`;
+  }
+
+  console.info(`Delete old data cron completed successfully.\nMetadata: ${response.meta}`);
+  return response.meta;
+}
+
+export default delete_old_data_cron;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,9 @@ import { streamResponse } from "./utils";
 import { Bindings } from "./bindings";
 import HeaderUtils from "./header_utils";
 import analytics from "./middleware/analytics";
+import cron from "./crons/cron";
 
-const app = new Hono<{ Bindings: Bindings }>();
+export const app = new Hono<{ Bindings: Bindings }>();
 
 app.use("*", analytics());
 
@@ -72,4 +73,7 @@ app.all("*", async (context: Context<{Bindings: Bindings}>) => {
   return streamResponse(response.body);
 });
 
-export default app;
+export default {
+  fetch: app.fetch,
+  scheduled: cron,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,3 +6,12 @@ export enum ServiceAuthType {
 export type Error = {
   error: string;
 };
+
+export type D1ResultMeta = {
+  served_by: string,
+  duration: number,
+  changes: number,
+  last_row_id: number,
+  changed_db: boolean,
+  size_after: number
+}

--- a/tests/compute_renderer.test.ts
+++ b/tests/compute_renderer.test.ts
@@ -1,4 +1,4 @@
-import app from "../src";
+import { app } from "../src";
 import { BINDINGS, getMockComputeRenderer, setInMemoryD1Database } from "./utils";
 import { RequestModel } from "../src/d1/models";
 

--- a/tests/crons.test.ts
+++ b/tests/crons.test.ts
@@ -1,0 +1,69 @@
+import { BINDINGS, setInMemoryD1Database } from "./utils";
+import delete_old_data_cron from "../src/crons/delete_old_data_cron";
+import { Bindings } from "../src/bindings";
+import { D1ResultMeta } from "../src/types";
+
+describe("Test all the cron jobs", () => {
+  beforeAll(async () => {
+    BINDINGS["DB"] = await setInMemoryD1Database();
+  });
+
+  // seed the database with 100 rows to test cron jobs
+  beforeEach(async () => {
+    const db = BINDINGS["DB"];
+    const stmt = db.prepare(`
+      INSERT INTO requests(user_agent,
+                           created_at,
+                           cf_connecting_ip,
+                           cf_ip_country,
+                           service_id,
+                           service_name,
+                           identifier_for_vendor,
+                           bundle_identifier,
+                           url,
+                           headers,
+                           status_code,
+                           error,
+                           bundle_version)
+      VALUES ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36',
+              datetime('now', '-1 day'),
+              '192.168.1.1',
+              'US',
+              'com.apple.assistant.assistantd',
+              'Assistant',
+              'com.apple.assistant.assistantd.00000000-0000-0000-0000-000000000000',
+              'com.apple.assistant.assistantd',
+              'https://www.open_ai.com',
+              '{
+                "Accept": "*/*",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Connection": "keep-alive"
+              }',
+              200,
+              null,
+              'unknown version')
+  `);
+
+    await db.batch(Array(100).fill(stmt));
+  });
+
+  it("should test delete_old_data_cron to delete data older than X days", async () => {
+    // Change the value of DELETE_OLD_DATA_BEFORE to delete data older than 12 hours
+    BINDINGS["DELETE_OLD_DATA_BEFORE"] = "-12 hours";
+
+    const meta: D1ResultMeta = await delete_old_data_cron(<Bindings>BINDINGS);
+
+    expect(meta.changes).toBe(100);
+  });
+
+  it("should not delete data that is not older than X days", async () => {
+    // Change the value of DELETE_OLD_DATA_BEFORE to delete data older than 7 days
+    BINDINGS["DELETE_OLD_DATA_BEFORE"] = "-7 day";
+
+    const meta: D1ResultMeta = await delete_old_data_cron(<Bindings>BINDINGS);
+
+    expect(meta.changes).toBe(0);
+  });
+
+});

--- a/tests/db.log.test.ts
+++ b/tests/db.log.test.ts
@@ -1,5 +1,5 @@
 import { BINDINGS, getMockOpenAI, setInMemoryD1Database } from "./utils";
-import app from "../src";
+import { app } from "../src";
 import { RequestModel } from "../src/d1/models";
 
 

--- a/tests/domain-availability.whoisxmlapi.test.ts
+++ b/tests/domain-availability.whoisxmlapi.test.ts
@@ -1,4 +1,4 @@
-import app from "../src";
+import { app } from "../src";
 import { BINDINGS, getMockDomainAvailabilityWhoIsXmlApi, setInMemoryD1Database } from "./utils";
 import { RequestModel } from "../src/d1/models";
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import app from "../src";
+import { app } from "../src";
 import { BINDINGS, getMockOpenAI, setInMemoryD1Database } from "./utils";
 import { RequestModel } from "../src/d1/models";
 

--- a/tests/open_ai.test.ts
+++ b/tests/open_ai.test.ts
@@ -1,4 +1,4 @@
-import app from "../src";
+import { app } from "../src";
 import { BINDINGS, getMockOpenAI, setInMemoryD1Database } from "./utils";
 import { RequestModel } from "../src/d1/models";
 

--- a/tests/shodan.test.ts
+++ b/tests/shodan.test.ts
@@ -1,4 +1,4 @@
-import app from "../src";
+import { app } from "../src";
 import { BINDINGS, getMockShodan, setInMemoryD1Database } from "./utils";
 import { RequestModel } from "../src/d1/models";
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_date = "2023-10-30"
 ############################# LOCAL #################################
 
 [triggers]
-crons = ["0 0 */7 * *"] # At 12:00 AM, every 7 days
+crons = ["0 0 * * SUN"] # At 12:00 AM, every sunday
 
 [[d1_databases]]
 binding = "DB"
@@ -16,6 +16,7 @@ migrations_dir = "migrations"
 
 [vars]
 DELETE_OLD_DATA_BEFORE = "-5 minutes" # Standard SQL format
+DELETE_OLD_DATA_CRON = "0 0 * * SUN" # check crons under triggers section
 
 ############################# PRODUCTION #############################
 
@@ -23,7 +24,7 @@ DELETE_OLD_DATA_BEFORE = "-5 minutes" # Standard SQL format
 name = "gateway"
 
 [env.production.triggers]
-crons = ["0 0 */7 * *"] # At 12:00 AM, every 7 days
+crons = ["0 0 * * SUN"] # At 12:00 AM, every sunday
 
 [[env.production.d1_databases]]
 binding = "DB"
@@ -34,3 +35,4 @@ migrations_dir = "migrations"
 
 [env.production.vars]
 DELETE_OLD_DATA_BEFORE = "-3 months" # Standard SQL format
+DELETE_OLD_DATA_CRON = "0 0 * * SUN" # check crons under env.production.triggers section

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,9 @@ compatibility_date = "2023-10-30"
 
 ############################# LOCAL #################################
 
+[triggers]
+crons = ["0 0 */7 * *"] # At 12:00 AM, every 7 days
+
 [[d1_databases]]
 binding = "DB"
 database_name = "gateway_local"
@@ -11,10 +14,16 @@ database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 migrations_table = "migrations"
 migrations_dir = "migrations"
 
+[vars]
+DELETE_OLD_DATA_BEFORE = "-5 minutes" # Standard SQL format
+
 ############################# PRODUCTION #############################
 
 [env.production]
 name = "gateway"
+
+[env.production.triggers]
+crons = ["0 0 */7 * *"] # At 12:00 AM, every 7 days
 
 [[env.production.d1_databases]]
 binding = "DB"
@@ -22,3 +31,6 @@ database_name = "gateway"
 database_id = "bea25784-0c7b-46d3-a064-47b6ccafa92e"
 migrations_table = "migrations"
 migrations_dir = "migrations"
+
+[env.production.vars]
+DELETE_OLD_DATA_BEFORE = "-3 months" # Standard SQL format


### PR DESCRIPTION
issue: https://github.com/twodayslate/gateway/issues/15

The new cron job deletes data older than 90 days from the requests table. The cron is scheduled to run at 12:00 midnight every 7 days. It deletes data older than 90 days.